### PR TITLE
Counter example, pillar file: package name Counter-->MyCounter

### DIFF
--- a/Exercises/Counter/Exo-Counter.pillar
+++ b/Exercises/Counter/Exo-Counter.pillar
@@ -28,7 +28,7 @@ In this part, you will create your first class. In Pharo, a class is defined in 
 
 
 !!! Create a package
-Using the Browser create a package. The system will ask you a name, write ==Counter==. This new package is then created and added to the list. Figure *@figpackageCreated* shows the result of creating such a package.
+Using the Browser create a package. The system will ask you a name, write ==MyCounter==. This new package is then created and added to the list. Figure *@figpackageCreated* shows the result of creating such a package.
 
 !!! Create a class
 Creating a class requires five steps. They consist basically in editing the class definition template to specify the class you want to create.


### PR DESCRIPTION
The text in the pdf file is not consistent with the example. Here is the change for the pillar file only.

the text: "Using the Browser create a package. The system will ask you a name, write
Counter."

the example:
"
Object subclass: #Counter
instanceVariableNames: 'count'
classVariableNames: ''
package: 'MyCounter'
"